### PR TITLE
Add ability to mark answers, display score

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,30 +1,42 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import Head from 'next/head'
 
+import { PlayerContext } from './PlayerContext'
 
 type LayoutProps = {
     pageTitle: string;
     children: React.ReactNode;
 }
 
-const Layout = ({ pageTitle, children }: LayoutProps) => (
-    <>
-        <Head>
-            <title>{pageTitle}</title>
-            <meta property="og:title" content={pageTitle} key="title" />
-        </Head>
+const Layout = ({ pageTitle, children }: LayoutProps) => {
+    const { gameState, } = useContext(PlayerContext);
 
-        <div className='min-h-screen flex flex-col'>
-            {children}
+    const scoreMessage = gameState.correct.length === 0 && gameState.incorrect.length === 0
+        ? 'No answers yet'
+        : `Correct: ${gameState.correct.length} Incorrect: ${gameState.incorrect.length}`
 
-            <footer className='mt-auto self-center'>
-                <p className='p-6'>
-                    by <a className="underline hover:no-underline hover:bg-yellow-50 hover:text-black" href='https://www.daisybarrette.com/'>Daisy Barrette</a> on <a className="underline hover:no-underline hover:bg-yellow-50 hover:text-black" href='https://github.com/daisybarrette/quiz-game'>GitHub</a>
-                </p>
-            </footer>
-        </div>
-    </>
+    return (
+        <>
+            <Head>
+                <title>{pageTitle}</title>
+                <meta property="og:title" content={pageTitle} key="title" />
+            </Head>
 
-)
+            <div className='min-h-screen flex flex-col'>
+                <aside className='rounded-sm shadow-md shadow-black block w-[calc(12em+2vw)] ml-auto sticky top-0 p-2 bg-lightest-yellow text-center text-black text-shadow-none'>
+                    {scoreMessage}
+                </aside>
+
+                {children}
+
+                <footer className='mt-auto self-center'>
+                    <p className='p-6'>
+                        by <a className="underline hover:no-underline hover:bg-yellow-50 hover:text-black" href='https://www.daisybarrette.com/'>Daisy Barrette</a> on <a className="underline hover:no-underline hover:bg-yellow-50 hover:text-black" href='https://github.com/daisybarrette/quiz-game'>GitHub</a>
+                    </p>
+                </footer>
+            </div>
+        </>
+    )
+}
 
 export default Layout

--- a/src/components/PlayerContext.tsx
+++ b/src/components/PlayerContext.tsx
@@ -1,9 +1,24 @@
 import { createContext } from 'react';
 
 
-export const PlayerContext = createContext({
-    gameState: {},
-    setGameState: (data: any) => { },
-    // setGameState: (setGameStateFunc: (value: string) => void) => { },
+type GameStateType = {
+    unanswered: string[],
+    correct: string[],
+    incorrect: string[],
+}
+
+type PlayerContextType = {
+    gameState: GameStateType,
+    setGameState: (data: any) => void,
+}
+
+
+export const PlayerContext = createContext<PlayerContextType>({
+    gameState: {
+        unanswered: [],
+        correct: [],
+        incorrect: [],
+    },
+    setGameState: (data: GameStateType) => { },
 });
 

--- a/src/components/PlayerContext.tsx
+++ b/src/components/PlayerContext.tsx
@@ -12,7 +12,6 @@ type PlayerContextType = {
     setGameState: (data: any) => void,
 }
 
-
 export const PlayerContext = createContext<PlayerContextType>({
     gameState: {
         unanswered: [],

--- a/src/components/PlayerContext.tsx
+++ b/src/components/PlayerContext.tsx
@@ -1,3 +1,9 @@
 import { createContext } from 'react';
 
-export const PlayerContext = createContext({ answeredClues: [] });
+
+export const PlayerContext = createContext({
+    gameState: {},
+    setGameState: (data: any) => { },
+    // setGameState: (setGameStateFunc: (value: string) => void) => { },
+});
+

--- a/src/components/PlayerContext.tsx
+++ b/src/components/PlayerContext.tsx
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const PlayerContext = createContext({ answeredClues: [] });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,13 +2,15 @@ import React, { useState } from 'react'
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 
+import CLUES from '../definitions/clueData'
 import { PlayerContext } from '@/components/PlayerContext'
 
 
 export default function App({ Component, pageProps }: AppProps) {
     const [gameState, setGameState] = useState({
-        answeredClues: [],
-        unansweredClues: []
+        unanswered: CLUES.map(clue => clue.id),
+        correct: [],
+        incorrect: [],
     })
 
     console.table(gameState)
@@ -18,7 +20,6 @@ export default function App({ Component, pageProps }: AppProps) {
             gameState: gameState,
             setGameState: setGameState,
         }}>
-            <span className='text-5xl'>{`${gameState.info}`}</span>
             <Component {...pageProps} />
         </PlayerContext.Provider>
     )

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,8 +13,6 @@ export default function App({ Component, pageProps }: AppProps) {
         incorrect: [],
     })
 
-    console.table(gameState)
-
     return (
         <PlayerContext.Provider value={{
             gameState: gameState,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,25 @@
+import React, { useState } from 'react'
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 
+import { PlayerContext } from '@/components/PlayerContext'
+
+
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+    const [gameState, setGameState] = useState({
+        answeredClues: [],
+        unansweredClues: []
+    })
+
+    console.table(gameState)
+
+    return (
+        <PlayerContext.Provider value={{
+            gameState: gameState,
+            setGameState: setGameState,
+        }}>
+            <span className='text-5xl'>{`${gameState.info}`}</span>
+            <Component {...pageProps} />
+        </PlayerContext.Provider>
+    )
 }

--- a/src/pages/clue/[id].tsx
+++ b/src/pages/clue/[id].tsx
@@ -13,7 +13,7 @@ type ClueType = {
 }
 
 function Clue({ clueData }: { clueData: ClueType }) {
-    const [hasBeenClicked, setHasBeenClicked] = useState(false)
+    const [hasRevealBeenClicked, sethasRevealBeenClicked] = useState(false)
 
     const { gameState, setGameState } = useContext(PlayerContext);
 
@@ -28,10 +28,10 @@ function Clue({ clueData }: { clueData: ClueType }) {
                     className="flex flex-col justify-center w-[calc(12rem_+_20vw)] h-[calc(8rem_+_20vh)]"
                 >
                     <button
-                        className={`${hasBeenClicked ? 'hidden' : 'block'} py-8 px-10 ${primaryLinkStyles}`}
+                        className={`${hasRevealBeenClicked ? 'hidden' : 'block'} py-8 px-10 ${primaryLinkStyles}`}
                         type="button"
                         onClick={() => {
-                            setHasBeenClicked(true)
+                            sethasRevealBeenClicked(true)
                             setGameState({
                                 ...gameState,
                             })
@@ -40,12 +40,14 @@ function Clue({ clueData }: { clueData: ClueType }) {
                         {'Reveal answer'}
                     </button>
 
-                    <p className={`${hasBeenClicked ? 'block' : 'hidden'} text-xl`}>
+                    <p className={`${hasRevealBeenClicked ? 'block' : 'hidden'} text-xl`}>
                         {`${clueData.answer}`}
                     </p>
+                </div>
 
+                <div className='flex items-center  h-[calc(1rem_+_8vh)]'>
                     <button
-                        className={`${hasBeenClicked ? 'block' : 'hidden'} py-8 px-10 ${primaryLinkStyles}`}
+                        className={`${hasRevealBeenClicked && gameState.unanswered.includes(clueData.id) ? 'block' : 'hidden'} py-8 px-10 ${primaryLinkStyles}`}
                         onClick={() => {
                             const updatedGameState = {
                                 ...gameState,
@@ -60,7 +62,7 @@ function Clue({ clueData }: { clueData: ClueType }) {
                     </button>
 
                     <button
-                        className={`${hasBeenClicked ? 'block' : 'hidden'} py-8 px-10 ${primaryLinkStyles}`}
+                        className={`${hasRevealBeenClicked && gameState.unanswered.includes(clueData.id) ? 'block' : 'hidden'} py-8 px-10 ${primaryLinkStyles}`}
                         onClick={() => {
                             const updatedGameState = {
                                 ...gameState,
@@ -73,6 +75,10 @@ function Clue({ clueData }: { clueData: ClueType }) {
                     >
                         {'Wrong'}
                     </button>
+
+                    <p className={`${hasRevealBeenClicked && !gameState.unanswered.includes(clueData.id) ? 'block' : 'hidden'} text-xl`}>
+                        {`Answer marked ${gameState.correct.includes(clueData.id) ? 'correct' : 'incorrect'}`}
+                    </p>
                 </div>
 
                 <PrimaryLink

--- a/src/pages/clue/[id].tsx
+++ b/src/pages/clue/[id].tsx
@@ -14,7 +14,6 @@ type ClueType = {
 
 function Clue({ clueData }: { clueData: ClueType }) {
     const [hasRevealBeenClicked, sethasRevealBeenClicked] = useState(false)
-
     const { gameState, setGameState } = useContext(PlayerContext);
 
     return (

--- a/src/pages/clue/[id].tsx
+++ b/src/pages/clue/[id].tsx
@@ -22,10 +22,10 @@ function Clue({ clueData }: { clueData: ClueType }) {
             pageTitle="Trivia Game | Clue"
         >
             <main className="flex flex-col items-center text-center">
-                <h1 className="text-2xl mt-24 p-10 w-9/12">{`${clueData.clue}`}</h1>
+                <h1 className="mt-[calc(1rem_+_10vh+5vw)] w-9/12 text-2xl ">{`${clueData.clue}`}</h1>
 
                 <div
-                    className="flex flex-col justify-center w-[calc(12rem_+_20vw)] h-[calc(8rem_+_20vh)]"
+                    className="flex flex-col justify-center w-[calc(12rem_+_20vw)] h-[calc(4rem_+_18vh)]"
                 >
                     <button
                         className={`${hasRevealBeenClicked ? 'hidden' : 'block'} py-8 px-10 ${primaryLinkStyles}`}
@@ -45,7 +45,7 @@ function Clue({ clueData }: { clueData: ClueType }) {
                     </p>
                 </div>
 
-                <div className='flex items-center  h-[calc(1rem_+_8vh)]'>
+                <div className='flex items-center h-[calc(1rem_+_8vh)]'>
                     <button
                         className={`${hasRevealBeenClicked && gameState.unanswered.includes(clueData.id) ? 'block' : 'hidden'} py-8 px-10 ${primaryLinkStyles}`}
                         onClick={() => {
@@ -76,7 +76,7 @@ function Clue({ clueData }: { clueData: ClueType }) {
                         {'Wrong'}
                     </button>
 
-                    <p className={`${hasRevealBeenClicked && !gameState.unanswered.includes(clueData.id) ? 'block' : 'hidden'} text-xl`}>
+                    <p className={`${hasRevealBeenClicked && !gameState.unanswered.includes(clueData.id) ? 'block' : 'hidden'} text-m`}>
                         {`Answer marked ${gameState.correct.includes(clueData.id) ? 'correct' : 'incorrect'}`}
                     </p>
                 </div>

--- a/src/pages/clue/[id].tsx
+++ b/src/pages/clue/[id].tsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
 import Link from 'next/link'
 
 import CLUES from '../../definitions/clueData'
 import Layout from '../../components/Layout'
+import PlayerContext from '../../components/PlayerContext'
+
 
 
 type ClueType = {
@@ -13,6 +15,7 @@ type ClueType = {
 
 function Clue({ clueData }: { clueData: ClueType }) {
     const [hasBeenClicked, setHasBeenClicked] = useState(false)
+    // const
 
     return (
         <Layout

--- a/src/pages/clue/[id].tsx
+++ b/src/pages/clue/[id].tsx
@@ -34,7 +34,6 @@ function Clue({ clueData }: { clueData: ClueType }) {
                             setHasBeenClicked(true)
                             setGameState({
                                 ...gameState,
-                                clueTest: 'answered',
                             })
                         }}
                     >
@@ -50,15 +49,29 @@ function Clue({ clueData }: { clueData: ClueType }) {
                         onClick={() => {
                             const updatedGameState = {
                                 ...gameState,
-                                unansweredClues: gameState.unansweredClues.filter(id => id === clueData.id),
-                                answeredClues: [...gameState.answeredClues, clueData.id]
-
+                                unanswered: gameState.unanswered.filter(id => id !== clueData.id),
+                                correct: [...gameState.correct, clueData.id],
                             }
 
                             setGameState(updatedGameState)
                         }}
                     >
-                        {'mark answered'}
+                        {'Right'}
+                    </button>
+
+                    <button
+                        className={`${hasBeenClicked ? 'block' : 'hidden'} py-8 px-10 ${primaryLinkStyles}`}
+                        onClick={() => {
+                            const updatedGameState = {
+                                ...gameState,
+                                unanswered: gameState.unanswered.filter(id => id !== clueData.id),
+                                incorrect: [...gameState.incorrect, clueData.id],
+                            }
+
+                            setGameState(updatedGameState)
+                        }}
+                    >
+                        {'Wrong'}
                     </button>
                 </div>
 

--- a/src/pages/clue/[id].tsx
+++ b/src/pages/clue/[id].tsx
@@ -3,7 +3,7 @@ import React, { useState, useContext } from 'react'
 import CLUES from '../../definitions/clueData'
 import Layout from '../../components/Layout'
 import PrimaryLink, { primaryLinkStyles } from '../../components/PrimaryLink'
-import PlayerContext from '../../components/PlayerContext'
+import { PlayerContext } from '../../components/PlayerContext'
 
 
 type ClueType = {
@@ -14,7 +14,8 @@ type ClueType = {
 
 function Clue({ clueData }: { clueData: ClueType }) {
     const [hasBeenClicked, setHasBeenClicked] = useState(false)
-    // const
+
+    const { gameState, setGameState } = useContext(PlayerContext);
 
     return (
         <Layout
@@ -29,7 +30,13 @@ function Clue({ clueData }: { clueData: ClueType }) {
                     <button
                         className={`${hasBeenClicked ? 'hidden' : 'block'} py-8 px-10 ${primaryLinkStyles}`}
                         type="button"
-                        onClick={() => setHasBeenClicked(true)}
+                        onClick={() => {
+                            setHasBeenClicked(true)
+                            setGameState({
+                                ...gameState,
+                                clueTest: 'answered',
+                            })
+                        }}
                     >
                         {'Reveal answer'}
                     </button>
@@ -37,6 +44,22 @@ function Clue({ clueData }: { clueData: ClueType }) {
                     <p className={`${hasBeenClicked ? 'block' : 'hidden'} text-xl`}>
                         {`${clueData.answer}`}
                     </p>
+
+                    <button
+                        className={`${hasBeenClicked ? 'block' : 'hidden'} py-8 px-10 ${primaryLinkStyles}`}
+                        onClick={() => {
+                            const updatedGameState = {
+                                ...gameState,
+                                unansweredClues: gameState.unansweredClues.filter(id => id === clueData.id),
+                                answeredClues: [...gameState.answeredClues, clueData.id]
+
+                            }
+
+                            setGameState(updatedGameState)
+                        }}
+                    >
+                        {'mark answered'}
+                    </button>
                 </div>
 
                 <PrimaryLink

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ import { PlayerContext } from '../components/PlayerContext'
 
 
 function Home() {
-    const { gameState, setGameState } = useContext(PlayerContext);
+    const { gameState, } = useContext(PlayerContext);
     return (
         <Layout
             pageTitle="Trivia Game | Home"
@@ -21,7 +21,7 @@ function Home() {
                             <li className="flex w-full shadow-md shadow-black" key={clue.id}>
                                 <ClueLink
                                     id={clue.id}
-                                    isAnswered={gameState.answeredClues.includes(clue.id)}
+                                    isAnswered={!gameState.unanswered.includes(clue.id)}
                                 />
                             </li>
                         ))}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,27 +2,30 @@ import Link from 'next/link'
 
 import CLUES from '../definitions/clueData'
 import Layout from '../components/Layout'
+import { PlayerContext } from '../components/PlayerContext'
 
 
 function Home() {
     return (
-        <Layout
-            pageTitle="Trivia Game | Home"
-        >
-            <main className="flex flex-col items-center text-center">
-                <h1 className="header text-5xl py-[calc(2rem_+_2vh+1vw)]">Computer Science Trivia</h1>
 
-                <div className='w-full mt-2.5 text-center p-2.5'>
-                    <ul className="m-auto min-w-[40%] max-w-xs grid grid-cols-3 grid-rows-3 gap-6 auto-cols-fr justify-items-center list-none text-xl">
-                        {CLUES.map(clue => (
-                            <li className="flex w-full" key={clue.id}>
-                                <ClueLink id={clue.id} />
-                            </li>
-                        ))}
-                    </ul>
-                </div>
-            </main>
-        </Layout >
+            <Layout
+                pageTitle="Trivia Game | Home"
+            >
+                <main className="flex flex-col items-center text-center">
+                    <h1 className="header text-5xl py-[calc(2rem_+_2vh+1vw)]">Computer Science Trivia</h1>
+
+                    <div className='w-full mt-2.5 text-center p-2.5'>
+                        <ul className="m-auto min-w-[40%] max-w-xs grid grid-cols-3 grid-rows-3 gap-6 auto-cols-fr justify-items-center list-none text-xl">
+                            {CLUES.map(clue => (
+                                <li className="flex w-full" key={clue.id}>
+                                    <ClueLink id={clue.id} />
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </main>
+            </Layout >
+
     )
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link'
+import React, { useContext } from 'react'
 
 import CLUES from '../definitions/clueData'
 import Layout from '../components/Layout'
@@ -7,6 +7,7 @@ import { PlayerContext } from '../components/PlayerContext'
 
 
 function Home() {
+    const { gameState, setGameState } = useContext(PlayerContext);
     return (
         <Layout
             pageTitle="Trivia Game | Home"
@@ -18,22 +19,27 @@ function Home() {
                     <ul className="m-auto min-w-[40%] max-w-xs grid grid-cols-3 grid-rows-3 gap-6 auto-cols-fr justify-items-center list-none text-xl">
                         {CLUES.map(clue => (
                             <li className="flex w-full shadow-md shadow-black" key={clue.id}>
-                                <ClueLink id={clue.id} />
+                                <ClueLink
+                                    id={clue.id}
+                                    isAnswered={gameState.answeredClues.includes(clue.id)}
+                                />
                             </li>
                         ))}
                     </ul>
                 </div>
             </main>
         </Layout >
-
     )
 }
 
-function ClueLink({ id }: { id: string }) {
+function ClueLink({ id, isAnswered }: { id: string, isAnswered: boolean }) {
     const value = `$${id}00`
+    const spacingStyles = "w-full py-[calc(0.7rem_+_2vw)]"
+    const answeredStyles = isAnswered ? 'bg-yellow-500' : ''
+
     return (
         <PrimaryLink
-            customStyles="w-full py-[calc(0.7rem_+_2vw)]"
+            customStyles={`${spacingStyles} ${answeredStyles}`}
             aria-label="View clue"
             href={`/clue/${id}`}
         >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react'
 
 import CLUES from '../definitions/clueData'
 import Layout from '../components/Layout'
-import PrimaryLink from '../components/PrimaryLink'
+import PrimaryLink, { primaryLinkStyles } from '../components/PrimaryLink'
 import { PlayerContext } from '../components/PlayerContext'
 
 
@@ -35,16 +35,20 @@ function Home() {
 function ClueLink({ id, isAnswered }: { id: string, isAnswered: boolean }) {
     const value = `$${id}00`
     const spacingStyles = "w-full py-[calc(0.7rem_+_2vw)]"
-    const answeredStyles = isAnswered ? 'bg-yellow-500' : ''
+    const answeredStyles = 'shadow-inner shadow-black bg-dark-blue'
 
     return (
-        <PrimaryLink
-            customStyles={`${spacingStyles} ${answeredStyles}`}
+        isAnswered ? (
+            <div className={`${spacingStyles} ${answeredStyles}`}/>
+        )
+        :
+        (<PrimaryLink
+            customStyles={spacingStyles}
             aria-label="View clue"
             href={`/clue/${id}`}
         >
             {value}
-        </PrimaryLink>
+        </PrimaryLink>)
     )
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,6 +33,12 @@ html {
     font-size: 16px;
 }
 
+@media only screen and (max-width: 345px) {
+    html {
+        font-size: 12px;
+    }
+}
+
 *::selection {
     background-color: var(--accent);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ module.exports = {
             colors: {
                 'dark-blue': '#1812b2',
                 'light-yellow': '#fcd393',
+                'lightest-yellow': '#fcf4e8',
             },
         },
     },


### PR DESCRIPTION
New features:
- users can mark a question as correct or incorrect after revealing the answer
- answered questions are removed from the home page (empty/blue square shown instead)
- number of correct & incorrect answers displayed in the top right corner
- adjusted sizing for very small screens (iPhone 5 and smaller)

Future improvements:
- use the dollar values to display the actual score
- update the clues themselves so the difficulty values make more sense